### PR TITLE
[ Feat ] Implementation of magic link feature and expose `request`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - **🥳 Easy to Setup**. The Strategy will handle the entire Authentication flow for you.
 - **🔐 Secure**. The OTP code is encrypted and signed with a Secret Key.
 - **📚 One Source of Truth**. The database of your choice.
-- **📧 Magic Link built-in**. You can send a Magic Link to the user to authenticate with a simple click.
+- **📧 Magic Link Built-In**. Send a Magic Link to the user and authenticate it with a simple click.
 - **🛡 Bulletproof**. Written in strict TypeScript with a high test coverage.
 - **🗂 Typed**. Ships with types included.
 - **🚀 Built on top of Remix Auth**. An amazing authentication library for Remix.
@@ -34,7 +34,7 @@ Feel free to check and test it at [Remix Auth OTP Stack](https://remix-auth-otp.
 This Strategy uses a Passwordless Authentication Flow based on Email-Code validation.<br />
 
 The user will receive an email with a code that will be used to authenticate itself.<br />
-The code has just one use and it's valid for a short period of time, which makes it very secure.<br />
+The code has just a single use and it's valid for a short period of time, which makes it very secure.<br />
 
 Let's see how we can implement this Strategy for our Remix App.
 
@@ -213,7 +213,7 @@ authenticator.use(
             </head>
             <body>
               <h1>Code: ${code}</h1>
-              <p>Alternatively, you can click the magic link: ${magicLink}</p>
+              ${magicLink && `<p>Alternatively, you can click the Magic Link: ${magicLink}</p>`}
             </body>
           </html>
           `
@@ -224,7 +224,7 @@ authenticator.use(
 
     /**
      * Validates the OTP code.
-     * It should return a Promise<{ code: string, active: boolean }>.
+     * It should return a Promise<{ code: string, active: boolean, attempts: number }>.
      */
     validateCode: async (code) => {
       const otp = await db.otp.findUnique({
@@ -281,16 +281,16 @@ authenticator.use(
       // ...
     },
     async ({ email, code, magicLink, form, request }) => {
-      // You can determine whether the user is authenticating 
-      // via OTP submission or magic link and run your own logic
+      // You can determine whether the user is authenticating
+      // via OTP submission or Magic Link and run your own logic.
       if (form) {
-        console.log('OTP code form submission')
+        console.log('OTP code form submission.')
       }
 
       if (magicLink) {
-        console.log('Magic link clicked')
+        console.log('Magic Link clicked.')
       }
-      
+
       // Gets user from database.
       // This is the right place to create a new user (if not exists).
       const user = await db.user.findFirst({
@@ -466,22 +466,22 @@ export async function action({ request }: DataFunctionArgs) {
 ```
 
 ```tsx
-import type { DataFunctionArgs } from '@remix-run/node';
-import { authenticator } from '~/services/auth.server';
+// app/routes/magic-link.tsx
+import type { DataFunctionArgs } from '@remix-run/node'
+import { authenticator } from '~/services/auth.server'
 
 export async function loader({ request, params }: DataFunctionArgs) {
   const user = await authenticator.isAuthenticated(request, {
     successRedirect: '/account',
-  });
+  })
 
   if (!user) {
     await authenticator.authenticate('OTP', request, {
       successRedirect: '/account',
       failureRedirect: '/login',
-    });
+    })
   }
 }
-
 ```
 
 ## Options and Customization
@@ -502,7 +502,7 @@ authenticator.use(
       // Do something with the email.
     },
     // storeCode: async (code) => {},
-    // sendCode: async ({ email, code, user, form }) => {},
+    // sendCode: async ({ email, ... }) => {},
     // ...
   }),
 )
@@ -564,7 +564,7 @@ authenticator.use(
       // ... other options.
     },
     // storeCode: async (code) => {},
-    // sendCode: async ({ email, code, user, form }) => {},
+    // sendCode: async ({ email, ... }) => {},
     // ...
   }),
 )
@@ -575,26 +575,27 @@ authenticator.use(
 The Magic Link is optional and enabled by default. You can decide to opt-out by setting the `enabled` option to `false`. Furthermore, the Magic Link can be customized via the `magicLinkGeneration` object in the OTPStrategy instance.
 
 The link generated will be in the format of `https://{baseUrl}{callbackPath}?{codeField}=<magic-link-code>`.
- 
+
 ```ts
 /**
- * The magic link configuration.
+ * The Magic Link configuration.
  */
 export interface MagicLinkGenerationOptions {
   /**
-   * Whether to enable the magic link feature.
+   * Whether to enable the Magic Link feature.
    * @default true
    */
   enabled?: boolean
 
   /**
-   * The base Url for building the magic link url. If omitted, the baseUrl will be inferred from the request.
+   * The base URL for building the Magic Link URL.
+   * If omitted, the `baseUrl` will be inferred from the request.
    * @default undefined
    */
   baseUrl?: string
 
   /**
-   * The path for the magic link callback.
+   * The path for the Magic Link callback.
    * @default '/magic-link'
    */
   callbackPath?: string
@@ -602,8 +603,6 @@ export interface MagicLinkGenerationOptions {
 ```
 
 > **Note:** Just enabling the Magic Link feature is not enough, you will need to also [implement the `callbackPath` route](#auth-routes).
-
-```tsx
 
 ### More Options
 
@@ -647,6 +646,10 @@ export interface OTPStrategyOptions<User> {
 
 If you find this module useful, support it with a [Star ⭐](https://github.com/dev-xo/remix-auth-otp)<br />
 It helps the repository grow and gives me motivation to keep working on it. Thank you!
+
+### Acknowledgments
+
+Big thanks to [@w00fz](https://github.com/w00fz) for its amazing implementation of the Magic Link feature!
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - **🥳 Easy to Setup**. The Strategy will handle the entire Authentication flow for you.
 - **🔐 Secure**. The OTP code is encrypted and signed with a Secret Key.
 - **📚 One Source of Truth**. The database of your choice.
+- **📧 Magic Link built-in**. You can send a Magic Link to the user to authenticate with a simple click.
 - **🛡 Bulletproof**. Written in strict TypeScript with a high test coverage.
 - **🗂 Typed**. Ships with types included.
 - **🚀 Built on top of Remix Auth**. An amazing authentication library for Remix.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ authenticator.use(
     {
       secret: 'STRONG_SECRET_PLEASE_CHANGE_ME',
       storeCode: async (code) => {},
-      sendCode: async ({ email, code, user, ,magicLink, form, request }) => {},
+      sendCode: async ({ email, code, magicLink, user, form, request }) => {},
       validateCode: async (code) => {},
       invalidateCode: async (code, active, attempts) => {},
     },

--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ export interface MagicLinkGenerationOptions {
 
   /**
    * The base Url for building the magic link url. If omitted, the baseUrl will be inferred from the request.
-   * @default ''
+   * @default undefined
    */
   baseUrl?: string
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -403,8 +403,9 @@ export class OTPStrategy<User> extends Strategy<User, OTPVerifyParams> {
         // Either via Magic Link or OTP code submission.
         if (isGET && this.magicLinkGeneration.enabled) {
           const url = new URL(request.url)
+
           if (url.pathname !== this.magicLinkGeneration.callbackPath) {
-            throw new Error('Magic link does not match expected URL.')
+            throw new Error('Magic Link does not match expected path.')
           }
 
           magicLink = decodeURIComponent(url.searchParams.get(this.codeField) ?? '')
@@ -584,7 +585,7 @@ export class OTPStrategy<User> extends Strategy<User, OTPVerifyParams> {
 
   private async validateMagicLink(magicLink: string, sessionOtpEncrypted: string) {
     if (magicLink !== sessionOtpEncrypted) {
-      throw new Error('Magic Link does not match the expected signature.')
+      throw new Error('Magic Link does not match the expected Signature.')
     }
 
     const { otp, sessionOtp } = await this.validateOtpEncrypted(magicLink)

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export interface MagicLinkGenerationOptions {
 
   /**
    * The base Url for building the magic link url. If omitted, the baseUrl will be inferred from the request.
-   * @default ''
+   * @default undefined
    */
   baseUrl?: string
 
@@ -282,7 +282,7 @@ export class OTPStrategy<User> extends Strategy<User, OTPVerifyParams> {
 
   private readonly magicLinkGenerationDefaults = {
     enabled: true,
-    baseUrl: '',
+    baseUrl: undefined,
     callbackPath: '/magic-link',
   }
 
@@ -295,7 +295,7 @@ export class OTPStrategy<User> extends Strategy<User, OTPVerifyParams> {
     this.emailField = options.emailField ?? 'email'
     this.codeField = options.codeField ?? 'code'
     this.codeGeneration = options.codeGeneration ?? this.codeGenerationDefaults
-    this.magicLinkGeneration = options.magicLinkGeneration ?? this.magicLinkGenerationDefaults
+    this.magicLinkGeneration = { ...this.magicLinkGenerationDefaults, ...options.magicLinkGeneration }
     this.validateEmail = options.validateEmail ?? this.validateEmailDefaults
     this.storeCode = options.storeCode
     this.sendCode = options.sendCode

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,24 +64,24 @@ export interface CodeGenerationOptions {
 }
 
 /**
- * The magic link configuration.
+ * The Magic Link configuration.
  */
 export interface MagicLinkGenerationOptions {
   /**
-   * Whether to enable the magic link feature.
+   * Whether to enable the Magic Link feature.
    * @default true
    */
   enabled?: boolean
 
   /**
-   * The base Url for building the magic link url.
+   * The base Url for building the Magic Link url.
    * If omitted, the baseUrl will be inferred from the request.
    * @default undefined
    */
   baseUrl?: string
 
   /**
-   * The path for the magic link callback.
+   * The path for the Magic Link callback.
    * @default '/magic-link'
    */
   callbackPath?: string
@@ -110,7 +110,7 @@ export interface SendCodeOptions<User> {
   code: string
 
   /**
-   * The magic link URL.
+   * The Magic Link URL.
    */
   magicLink?: string
 
@@ -185,7 +185,7 @@ export interface OTPStrategyOptions<User> {
   codeGeneration?: CodeGenerationOptions
 
   /**
-   * The magic link configuration.
+   * The Magic Link configuration.
    */
   magicLinkGeneration?: MagicLinkGenerationOptions
 
@@ -243,7 +243,7 @@ export interface OTPVerifyParams {
   code?: string
 
   /**
-   * The magic link URL used to trigger the authentication.
+   * The Magic Link URL used to trigger the authentication.
    */
   magicLink?: string
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -387,7 +387,7 @@ export class OTPStrategy<User> extends Strategy<User, OTPVerifyParams> {
           }
         }
 
-        if (isGet && this.magicLinkGeneration.enabled)) {
+        if (isGet && this.magicLinkGeneration.enabled) {
           // Handles magic link.
           const url = new URL(request.url)
           if (url.pathname !== this.magicLinkGeneration.callbackPath) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ export interface MagicLinkGenerationOptions {
   enabled?: boolean
 
   /**
-   * The base Url for building the Magic Link url.
+   * The base URL for building the Magic Link URL.
    * If omitted, the baseUrl will be inferred from the request.
    * @default undefined
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,8 +65,9 @@ export interface CodeGenerationOptions {
 export interface MagicLinkGenerationOptions {
   /**
    * Whether to enable the magic link feature.
+   * @default true
    */
-  enabled?: boolean;
+  enabled?: boolean
 
   /**
    * The base Url for building the magic link url. If omitted, the baseUrl will be inferred from the request.
@@ -106,7 +107,7 @@ export interface SendCodeOptions<User> {
   /**
    * The magic link url.
    */
-  magicLink: string | null
+  magicLink: string | undefined
 
   /**
    * The user object.
@@ -280,7 +281,7 @@ export class OTPStrategy<User> extends Strategy<User, OTPVerifyParams> {
   }
 
   private readonly magicLinkGenerationDefaults = {
-    enabled: false,
+    enabled: true,
     baseUrl: '',
     callbackPath: '/magic-link',
   }
@@ -479,10 +480,11 @@ export class OTPStrategy<User> extends Strategy<User, OTPVerifyParams> {
     await this.storeCode(code)
   }
 
-  private async sendOtp(email: string, code: string, magicLink: string | null, form: FormData, request: Request) {
+  private async sendOtp(email: string, code: string, magicLink: string | undefined, form: FormData, request: Request) {
     const user = await this.verify({
       email,
       code,
+      magicLink,
       form,
       request,
     }).catch(() => null)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,7 +35,7 @@ export function generateMagicLink(
     return undefined
   }
 
-  const url = new URL(options.callbackPath ?? '/', getBaseUrl(options.request))
+  const url = new URL(options.callbackPath ?? '/', options.baseUrl ?? getBaseUrl(options.request))
   url.searchParams.set(options.param, options.code)
 
   return url.toString()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import type { CodeGenerationOptions } from './index'
+import type { CodeGenerationOptions, MagicLinkGenerationOptions } from './index'
 import crypto from 'crypto-js'
 import otpGenerator from 'otp-generator'
 
@@ -25,4 +25,31 @@ export function generateOtp(options: CodeGenerationOptions) {
     code,
     createdAt,
   }
+}
+
+/** Magic Link URL */
+export function generateMagicLink(
+  options: MagicLinkGenerationOptions & { param: string; code: string; request: Request }
+) {
+  if (!options.enabled) {
+    return null;
+  }
+
+  const url = new URL(options.callbackPath ?? '/', getBaseUrl(options.request))
+  url.searchParams.set(options.param, options.code)
+
+  return url.toString()
+}
+
+export function getBaseUrl(request: Request) {
+  const host = request.headers.get('X-Forwarded-Host') ?? request.headers.get('host')
+
+  if (!host) {
+    throw new Error('Could not determine host.')
+  }
+
+  // If the host is localhost or ends with .local, use http.
+  const protocol = ['localhost', '127.0.0.1'].includes(host) || host.match(/\.local(:?:\d+)?$/) ? 'http' : 'https'
+
+  return `${protocol}://${host}`
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,7 +32,7 @@ export function generateMagicLink(
   options: MagicLinkGenerationOptions & { param: string; code: string; request: Request }
 ) {
   if (!options.enabled) {
-    return null;
+    return undefined
   }
 
   const url = new URL(options.callbackPath ?? '/', getBaseUrl(options.request))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,7 @@ export async function decrypt(value: string, secret: string): Promise<string> {
 }
 
 /**
- * OTP.
+ * OTP Generation.
  */
 export function generateOtp(options: CodeGenerationOptions) {
   const code = otpGenerator.generate(options.length, { ...options })
@@ -27,15 +27,24 @@ export function generateOtp(options: CodeGenerationOptions) {
   }
 }
 
-/** Magic Link URL */
+/**
+ * Magic Link Generation.
+ */
 export function generateMagicLink(
-  options: MagicLinkGenerationOptions & { param: string; code: string; request: Request }
+  options: MagicLinkGenerationOptions & {
+    param: string
+    code: string
+    request: Request
+  },
 ) {
   if (!options.enabled) {
     return undefined
   }
 
-  const url = new URL(options.callbackPath ?? '/', options.baseUrl ?? getBaseUrl(options.request))
+  const url = new URL(
+    options.callbackPath ?? '/',
+    options.baseUrl ?? getBaseUrl(options.request),
+  )
   url.searchParams.set(options.param, options.code)
 
   return url.toString()
@@ -49,7 +58,10 @@ export function getBaseUrl(request: Request) {
   }
 
   // If the host is localhost or ends with .local, use http.
-  const protocol = ['localhost', '127.0.0.1'].includes(host) || host.match(/\.local(:?:\d+)?$/) ? 'http' : 'https'
+  const protocol =
+    ['localhost', '127.0.0.1'].includes(host) || host.match(/\.local(:?:\d+)?$/)
+      ? 'http'
+      : 'https'
 
   return `${protocol}://${host}`
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -6,7 +6,7 @@ import { OTPStrategy } from '../src/index'
 import { encrypt, generateOtp } from '../src/utils'
 
 // Constants.
-const BASE_URL = 'localhost:3000'
+const HOST_URL = 'localhost:3000'
 const SECRET_ENV = 'SECRET'
 const OTP_DEFAULTS = {
   expiresAt: 1000 * 60 * 15,
@@ -56,7 +56,7 @@ describe('OTP Strategy', () => {
 
     test('Should throw an Error on missing required secret option.', async () => {
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
       })
 
@@ -85,7 +85,7 @@ describe('OTP Strategy', () => {
       formData.append('email', 'example@gmail.com')
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         body: formData,
       })
@@ -136,11 +136,11 @@ describe('OTP Strategy', () => {
       // formData.append('code', otp.code)
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
           cookie: await sessionStorage.commitSession(session),
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -188,11 +188,11 @@ describe('OTP Strategy', () => {
       // formData.append('code', otp.code)
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
           cookie: await sessionStorage.commitSession(session),
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -221,17 +221,17 @@ describe('OTP Strategy', () => {
     })
   })
 
-  describe('[ Authentication 1st - Without OTP Code ]', () => {
+  describe('[ 1st Authentication Phase ]', () => {
     test('Should throw an Error on missing email.', async () => {
       // Sets up testing data.
       const formData = new FormData()
       formData.append('email', '')
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -260,10 +260,10 @@ describe('OTP Strategy', () => {
       formData.append('email', 'invalid-email')
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -294,10 +294,10 @@ describe('OTP Strategy', () => {
       formData.append('email', 'example@gmail.com')
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -328,10 +328,10 @@ describe('OTP Strategy', () => {
       formData.append('email', 'example@gmail.com')
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -362,10 +362,10 @@ describe('OTP Strategy', () => {
       formData.append('email', 'example@gmail.com')
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -401,10 +401,10 @@ describe('OTP Strategy', () => {
       formData.append('email', 'example@gmail.com')
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -427,7 +427,7 @@ describe('OTP Strategy', () => {
     })
   })
 
-  describe('[ Authentication 2nd - With OTP Code ]', () => {
+  describe('[ 2nd Authentication Phase ]', () => {
     test('Should throw an Error on missing email from Session.', async () => {
       verify.mockImplementation(() => Promise.resolve())
 
@@ -439,11 +439,11 @@ describe('OTP Strategy', () => {
       formData.append('code', otp.code)
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
           cookie: await sessionStorage.commitSession(session),
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -487,11 +487,11 @@ describe('OTP Strategy', () => {
       formData.append('code', otp.code)
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
           cookie: await sessionStorage.commitSession(session),
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -534,11 +534,11 @@ describe('OTP Strategy', () => {
       formData.append('code', otp.code)
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
           cookie: await sessionStorage.commitSession(session),
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -585,11 +585,11 @@ describe('OTP Strategy', () => {
       formData.append('code', otp.code)
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
           cookie: await sessionStorage.commitSession(session),
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -636,11 +636,11 @@ describe('OTP Strategy', () => {
       formData.append('code', 'invalid-code')
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
           cookie: await sessionStorage.commitSession(session),
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -691,11 +691,11 @@ describe('OTP Strategy', () => {
       formData.append('code', otp.code)
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
           cookie: await sessionStorage.commitSession(session),
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -742,11 +742,11 @@ describe('OTP Strategy', () => {
       formData.append('code', 'invalid-code')
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
           cookie: await sessionStorage.commitSession(session),
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -798,11 +798,11 @@ describe('OTP Strategy', () => {
       formData.append('code', otp.code)
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
           cookie: await sessionStorage.commitSession(session),
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -851,11 +851,11 @@ describe('OTP Strategy', () => {
       formData.append('code', otp.code)
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
           cookie: await sessionStorage.commitSession(session),
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -901,11 +901,11 @@ describe('OTP Strategy', () => {
       formData.append('code', 'invalid-code')
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
           cookie: await sessionStorage.commitSession(session),
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -951,11 +951,11 @@ describe('OTP Strategy', () => {
       formData.append('code', otp.code)
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
           cookie: await sessionStorage.commitSession(session),
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })
@@ -1007,11 +1007,11 @@ describe('OTP Strategy', () => {
       formData.append('code', otp.code)
 
       // Creates Request.
-      const request = new Request(`${BASE_URL}`, {
+      const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
           cookie: await sessionStorage.commitSession(session),
-          host: BASE_URL,
+          host: HOST_URL,
         },
         body: formData,
       })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -6,7 +6,7 @@ import { OTPStrategy } from '../src/index'
 import { encrypt, generateOtp } from '../src/utils'
 
 // Constants.
-const BASE_URL = 'http://localhost:3000'
+const BASE_URL = 'localhost:3000'
 const SECRET_ENV = 'SECRET'
 const OTP_DEFAULTS = {
   expiresAt: 1000 * 60 * 15,
@@ -159,7 +159,7 @@ describe('OTP Strategy', () => {
       expect(invalidateCode).toHaveBeenCalledTimes(1)
     })
 
-    test('Should reassign form email with the one from the Session.', async () => {
+    test('Should reassign form email with the one stored in Session.', async () => {
       verify.mockImplementation(() => Promise.resolve())
 
       // Sets up testing data.
@@ -187,7 +187,10 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
-        headers: { cookie: await sessionStorage.commitSession(session) },
+        headers: {
+          cookie: await sessionStorage.commitSession(session),
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -284,6 +287,9 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
+        headers: {
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -315,6 +321,9 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
+        headers: {
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -346,6 +355,9 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
+        headers: {
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -382,6 +394,9 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
+        headers: {
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -978,4 +993,39 @@ describe('OTP Strategy', () => {
       expect(result.headers.get('Location')).toMatch('/account')
     })
   })
+
+  /* test.only('Should contain Location header pointing to provided successRedirect url.', async () => {
+    verify.mockImplementation(() => Promise.resolve({}))
+
+    // Sets up testing data.
+    const formData = new FormData()
+    formData.append('email', 'example@gmail.com')
+
+    // Creates Request.
+    const request = new Request(`${BASE_URL}`, {
+      method: 'POST',
+      headers: {
+        host: BASE_URL,
+      },
+      body: formData,
+    })
+
+    // Initializes Strategy.
+    const strategy = new OTPStrategy(
+      { secret: SECRET_ENV, storeCode, sendCode, validateCode, invalidateCode },
+      verify,
+    )
+
+    const result = await strategy
+      .authenticate(request, sessionStorage, {
+        ...BASE_OPTIONS,
+        successRedirect: '/verify',
+      })
+      .catch((error) => error)
+
+    console.log(result)
+
+    // Asserts.
+    // expect(result.headers.get('Location')).toMatch('/verify')
+  }) */
 })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -138,7 +138,10 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
-        headers: { cookie: await sessionStorage.commitSession(session) },
+        headers: {
+          cookie: await sessionStorage.commitSession(session),
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -227,6 +230,9 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
+        headers: {
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -256,6 +262,9 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
+        headers: {
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -432,7 +441,10 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
-        headers: { cookie: await sessionStorage.commitSession(session) },
+        headers: {
+          cookie: await sessionStorage.commitSession(session),
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -477,7 +489,10 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
-        headers: { cookie: await sessionStorage.commitSession(session) },
+        headers: {
+          cookie: await sessionStorage.commitSession(session),
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -521,7 +536,10 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
-        headers: { cookie: await sessionStorage.commitSession(session) },
+        headers: {
+          cookie: await sessionStorage.commitSession(session),
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -569,7 +587,10 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
-        headers: { cookie: await sessionStorage.commitSession(session) },
+        headers: {
+          cookie: await sessionStorage.commitSession(session),
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -617,7 +638,10 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
-        headers: { cookie: await sessionStorage.commitSession(session) },
+        headers: {
+          cookie: await sessionStorage.commitSession(session),
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -669,7 +693,10 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
-        headers: { cookie: await sessionStorage.commitSession(session) },
+        headers: {
+          cookie: await sessionStorage.commitSession(session),
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -717,7 +744,10 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
-        headers: { cookie: await sessionStorage.commitSession(session) },
+        headers: {
+          cookie: await sessionStorage.commitSession(session),
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -770,7 +800,10 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
-        headers: { cookie: await sessionStorage.commitSession(session) },
+        headers: {
+          cookie: await sessionStorage.commitSession(session),
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -820,7 +853,10 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
-        headers: { cookie: await sessionStorage.commitSession(session) },
+        headers: {
+          cookie: await sessionStorage.commitSession(session),
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -867,7 +903,10 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
-        headers: { cookie: await sessionStorage.commitSession(session) },
+        headers: {
+          cookie: await sessionStorage.commitSession(session),
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -914,7 +953,10 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
-        headers: { cookie: await sessionStorage.commitSession(session) },
+        headers: {
+          cookie: await sessionStorage.commitSession(session),
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -967,7 +1009,10 @@ describe('OTP Strategy', () => {
       // Creates Request.
       const request = new Request(`${BASE_URL}`, {
         method: 'POST',
-        headers: { cookie: await sessionStorage.commitSession(session) },
+        headers: {
+          cookie: await sessionStorage.commitSession(session),
+          host: BASE_URL,
+        },
         body: formData,
       })
 
@@ -993,39 +1038,4 @@ describe('OTP Strategy', () => {
       expect(result.headers.get('Location')).toMatch('/account')
     })
   })
-
-  /* test.only('Should contain Location header pointing to provided successRedirect url.', async () => {
-    verify.mockImplementation(() => Promise.resolve({}))
-
-    // Sets up testing data.
-    const formData = new FormData()
-    formData.append('email', 'example@gmail.com')
-
-    // Creates Request.
-    const request = new Request(`${BASE_URL}`, {
-      method: 'POST',
-      headers: {
-        host: BASE_URL,
-      },
-      body: formData,
-    })
-
-    // Initializes Strategy.
-    const strategy = new OTPStrategy(
-      { secret: SECRET_ENV, storeCode, sendCode, validateCode, invalidateCode },
-      verify,
-    )
-
-    const result = await strategy
-      .authenticate(request, sessionStorage, {
-        ...BASE_OPTIONS,
-        successRedirect: '/verify',
-      })
-      .catch((error) => error)
-
-    console.log(result)
-
-    // Asserts.
-    // expect(result.headers.get('Location')).toMatch('/verify')
-  }) */
 })


### PR DESCRIPTION
This PR enables the magic link feature which, alongside the OTP code, allows to also obtain a generated URL that can be treated for instant login and sent via email to the user.

The Magic Link feature is enabled by default, but one can decide to opt-out by disabling it via the `enabled` option. It also exposes two other configurational fields: `baseUrl` and `callbackPath`.

If omitted, `baseUrl` gets figured out automatically based on the URL the request happened from, otherwise it can be overridden. Example:

```ts
authenticator.use(
  new OTPStrategy(
    {
      // ...
      magicLinkGeneration: {
        enabled: true,
        baseUrl: 'https://always.use-production.com',
        callbackPath: '/auth-link',
      },
      // ...
```

Furthermore, this PR also exposes the `request` to the `verify` and `sendCode`. Useful for handling those cases where it is important to inspect the Request that the authentication came from (ie, evaluate the domain, inspect the headers, user-agent, etc).

Let me know what you think.

> **Note**
> I updated the README to document how to configure, opt-out and manage the magic link feature, hopefully up to the repository standard.

Fixes #4 