### PR TITLE
Feature: Session expiration for long-lasting auth ("Remember me"-like)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ authenticator.use(
 )
 ```
 
+> **Note**
+> You can specify how long a session should last by passing a `maxAge` value in milliseconds, to the strategy options object. The default value is `undefined`, which will not persist the session across browsers restarts. This is useful for a "Remember me" like feature.
+
 ### 2. Setting Up the Strategy Options.
 
 The Strategy Instance requires the following methods: `storeCode`, `sendCode`, `validateCode` and `invalidateCode`. It's important to note that all of them are required.
@@ -652,6 +655,12 @@ export interface OTPStrategyOptions<User> {
    * @default "code"
    */
   codeField?: string
+
+  /**
+   * The maximum age of the session in milliseconds. (remember me)
+   * @default undefined
+   */
+  maxAge?: number
 
   /**
    * A Session key that stores the email address.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ authenticator.use(
 ```
 
 > **Note**
-> You can specify how long a session should last by passing a `maxAge` value in milliseconds, to the strategy options object. The default value is `undefined`, which will not persist the session across browsers restarts. This is useful for a "Remember me" like feature.
+> You can specify how long a session should last by passing a `maxAge` value in milliseconds, to the strategy options object. The default value is `undefined`, which will not persist the session across browsers restarts. This is useful for a "Remember Me" like feature.
 
 ### 2. Setting Up the Strategy Options.
 
@@ -665,7 +665,7 @@ export interface OTPStrategyOptions<User> {
   codeField?: string
 
   /**
-   * The maximum age of the session in milliseconds. (remember me)
+   * The maximum age of the session in milliseconds. ("Remember Me" feature)
    * @default undefined
    */
   maxAge?: number

--- a/README.md
+++ b/README.md
@@ -236,15 +236,23 @@ authenticator.use(
     // Invalidate code.
     // It should return a Promise<void>.
     invalidateCode: async (code, active, attempts) => {
-      await db.otp.update({
-        where: {
-          code: code,
-        },
-        data: {
-          active: active,
-          attempts: attempts,
-        },
-      })
+      if (!active) {
+        await prisma.otp.delete({
+          where: {
+            code: code
+          }
+        })
+      } else {
+        await db.otp.update({
+          where: {
+            code: code,
+          },
+          data: {
+            active: active,
+            attempts: attempts,
+          },
+        })
+      }
     },
     async ({ email, code, magicLink, form, request }) => {},
   }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ export interface OTPStrategyOptions<User> {
   codeField?: string
 
   /**
-   * The maximum age of the session in milliseconds. (remember me)
+   * The maximum age of the session in milliseconds.
    * @default undefined
    */
   maxAge?: number

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,6 +209,12 @@ export interface OTPStrategyOptions<User> {
   codeField?: string
 
   /**
+   * The maximum age of the session in milliseconds. (remember me)
+   * @default undefined
+   */
+  maxAge?: number
+
+  /**
    * The validate email function.
    */
   validateEmail?: ValidateEmailFunction
@@ -299,6 +305,7 @@ export class OTPStrategy<User> extends Strategy<User, OTPVerifyParams> {
   private readonly secret: string
   private readonly emailField: string
   private readonly codeField: string
+  private readonly maxAge: number | undefined
   private readonly validateEmail: ValidateEmailFunction
   private readonly codeGeneration: CodeGenerationOptions
   private readonly magicLinkGeneration: MagicLinkGenerationOptions
@@ -340,6 +347,7 @@ export class OTPStrategy<User> extends Strategy<User, OTPVerifyParams> {
     this.secret = options.secret ?? ''
     this.emailField = options.emailField ?? 'email'
     this.codeField = options.codeField ?? 'code'
+    this.maxAge = options.maxAge ?? undefined
     this.validateEmail = options.validateEmail ?? this.validateEmailDefaults
     this.storeCode = options.storeCode
     this.sendCode = options.sendCode
@@ -439,7 +447,9 @@ export class OTPStrategy<User> extends Strategy<User, OTPVerifyParams> {
 
             throw redirect(options.successRedirect, {
               headers: {
-                'Set-Cookie': await sessionStorage.commitSession(session),
+                'Set-Cookie': await sessionStorage.commitSession(session, {
+                  maxAge: this.maxAge,
+                }),
               },
             })
           }
@@ -491,7 +501,9 @@ export class OTPStrategy<User> extends Strategy<User, OTPVerifyParams> {
 
           throw redirect(options.successRedirect, {
             headers: {
-              'Set-Cookie': await sessionStorage.commitSession(session),
+              'Set-Cookie': await sessionStorage.commitSession(session, {
+                maxAge: this.maxAge,
+              }),
             },
           })
         }


### PR DESCRIPTION
Sorry it took this long, but here is the feature that adds the ability to pass a `maxAge` option to extend the longevity of a session. This opens up the possibility to implement features such as Remember Me.

Usage example:
```ts
export const sessionMaxAge = 1000 * 60 * 60 * 24 * 30; // 30 days

authenticator.use(
  new OTPStrategy(
    {
      secret: process.env.MAGIC_LINK_SECRET,
      emailField: 'email',
      codeField: 'otp',
      maxAge: sessionMaxAge, // <-
      ...
```

Additionally, I have also updated the README to demo how one can auto-purge DB entries that will never be used again (since they are marked as inactive and served their purpose). This will ensure the DB won't grow too much over time.