### PR TITLE
[ Feat ]: Pass email to storeCode function.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ export interface MagicLinkGenerationOptions {
  * @param code The encrypted OTP code.
  */
 export interface StoreCodeFunction {
-  (code: string): Promise<void>
+  (code: string, email: string): Promise<void>
 }
 
 /**
@@ -438,7 +438,7 @@ export class OTPStrategy<User> extends Strategy<User, OTPVerifyParams> {
             })
 
             // Store and send the OTP code.
-            await this.saveOtp(otpEncrypted)
+            await this.saveOtp(otpEncrypted, email)
             await this.sendOtp(email, otp.code, magicLink, formData, request)
 
             session.set(this.sessionEmailKey, email)
@@ -551,8 +551,8 @@ export class OTPStrategy<User> extends Strategy<User, OTPVerifyParams> {
     }
   }
 
-  private async saveOtp(code: string) {
-    await this.storeCode(code)
+  private async saveOtp(code: string, email: string) {
+    await this.storeCode(code, email)
   }
 
   private async sendOtp(


### PR DESCRIPTION
Hey thanks a lot for this fantastic strategy 🙏🏼 

As I'm migrating my existing system back over to Remix and improving auth with remix-auth on the way I'd like to have access to the provided email address when storing the code in my db, I have 2 tables, login_session and login_token, and I store the email address in the token table as well, I guess I could update the token in the `sendCode` step, tho I think it'd be nicer to just do it in `storeCode` and the code looked straight forward to pass it along as a second argument, this way, instead of providing both in one or sthg, it doesn't break existing implementations.

Let me know what you think and/or if I missed anything.

Update: Also got a question, how/where could I best store additional information to redirect the user dynamically back to where they came from? `form` in the `sendCode` and verify functions seems to be always an empty object `{}`